### PR TITLE
strict mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A descriptive way to handle function arguments.
 ```js
 var argumenter = require('argumenter');
 function myFn(opt_fn, opt_options) {
-  var handler = argumenter(myFn);
+  var handler = argumenter(arguments);
 
   handler
     .when([Function, Object], function (fn, options) {
@@ -26,7 +26,7 @@ function myFn(opt_fn, opt_options) {
 ```js
 var argumenter = require('argumenter');
 function myFn() {
-  var handler = argumenter(myFn);
+  var handler = argumenter(arguments);
 
   handler
     .when(2, function (fn, options) {
@@ -41,11 +41,30 @@ function myFn() {
 }
 ```
 
+##Passing Parameters Explicitly
+
+```js
+var argumenter = require('argumenter');
+function myFn(foo, bar) {
+  var handler = argumenter(foo);
+
+  handler
+    .when(String, function(foo) {
+      // handle string
+    })
+    .when(Number, function(foo) {
+      // handle number
+    });
+
+  return handler.done();
+}
+```
+
 ##Returning the execution
 ```js
 var argumenter = require('argumenter');
 function myFn() {
-  var handler = argumenter(myFn);
+  var handler = argumenter(arguments);
 
   handler
     .when(2, function (a, b) {
@@ -70,7 +89,7 @@ var argumenter = require('argumenter');
 var context = {};
 
 function myFn(array) {
-  var handler = argumenter(myFn);
+  var handler = argumenter(arguments);
 
   handler.spread(0).spread(2)
     .when([Object, Function, Number, Array], function (obj, fn, number, array) {
@@ -88,7 +107,7 @@ var argumenter = require('argumenter');
 var context = {};
 
 function myFn() {
-  var handler = argumenter(myFn);
+  var handler = argumenter(arguments);
 
   handler
     .when(1, function (arg) {
@@ -98,3 +117,20 @@ function myFn() {
   return handler.done(context);
 }
 ```
+
+## Non-Strict Mode
+
+This module supports non-strict usage.  If you find it more convenient, you may pass the function itself to `argumenter()`:
+
+```js
+var argumenter = require('argumenter');
+function myFn(opt_fn, opt_options) {
+  var handler = argumenter(myFn);
+
+  handler
+    .when() // ...
+
+  return handler.done();
+```
+
+> Note: Attempting to pass a function to `argumenter()` while in strict mode will result in an exception thrown.

--- a/lib/argumenter.js
+++ b/lib/argumenter.js
@@ -1,9 +1,33 @@
-var strategies = require('./strategies');
+// do not 'use strict' here; this module supports non-strict usage.
+
+var strategies = require('./strategies')
+  , isArguments = require('is-arguments');
 
 module.exports = function (fn) {
   var self = {}
     , registeredStrategies = []
-    , spreads = [];
+    , spreads = []
+    , args
+    , strict = true;
+
+  try {
+    // in strict mode this will throw an exception.
+    // if it doesn't, support the pre-0.1.0 behavior, where
+    // we actually pass the function itself to argumenter().
+    args = Array.prototype.slice.call(fn.arguments);
+    strict = false;
+  } catch (e) {
+    if (typeof(fn) === 'function') {
+      throw new Error('cannot pass a function to argumenter() in strict mode.  pass "arguments" instead.');
+    }
+    // if the user passes arguments and only arguments, just use that
+    if (arguments.length === 1 && isArguments(fn)) {
+      args = Array.prototype.slice.call(fn);
+    } else {
+      args = Array.prototype.slice.call(arguments);
+    }
+
+  }
 
   function findMatch () {
     for (var index in registeredStrategies) {
@@ -21,9 +45,8 @@ module.exports = function (fn) {
     strategy = findMatch();
 
     if (strategy) {
-      return strategy.execute(context);
-    } else {
-      return undefined;
+      // if strict mode is true, then we don't pass the fn.
+      return strategy.execute(context, strict || fn);
     }
   };
 
@@ -36,9 +59,9 @@ module.exports = function (fn) {
   self.when = function (strategy, callback) {
 
     if (typeof strategy === 'function' || strategy instanceof Array) {
-      registeredStrategies.push(new strategies.ByType(strategy, callback, fn, spreads));
+      registeredStrategies.push(new strategies.ByType(strategy, callback, args, spreads));
     } else {
-      registeredStrategies.push(new strategies.ByLength(strategy, callback, fn, spreads));
+      registeredStrategies.push(new strategies.ByLength(strategy, callback, args, spreads));
     }
 
     return { when: self.when, done: self.done };

--- a/lib/argumenter.js
+++ b/lib/argumenter.js
@@ -1,7 +1,7 @@
 // do not 'use strict' here; this module supports non-strict usage.
 
 var strategies = require('./strategies')
-  , isArguments = require('is-arguments');
+  , type = require('type-of');
 
 module.exports = function (fn) {
   var self = {}
@@ -21,7 +21,7 @@ module.exports = function (fn) {
       throw new Error('cannot pass a function to argumenter() in strict mode.  pass "arguments" instead.');
     }
     // if the user passes arguments and only arguments, just use that
-    if (arguments.length === 1 && isArguments(fn)) {
+    if (arguments.length === 1 && type(fn) === 'arguments') {
       args = Array.prototype.slice.call(fn);
     } else {
       args = Array.prototype.slice.call(arguments);
@@ -35,8 +35,6 @@ module.exports = function (fn) {
         return registeredStrategies[index];
       }
     }
-
-    return null;
   }
 
   self.done = function done(context) {
@@ -58,10 +56,13 @@ module.exports = function (fn) {
 
   self.when = function (strategy, callback) {
 
-    if (typeof strategy === 'function' || strategy instanceof Array) {
+    var strategyType = type(strategy);
+    if (['array', 'null', 'function'].indexOf(strategyType) >= 0) {
       registeredStrategies.push(new strategies.ByType(strategy, callback, args, spreads));
-    } else {
+    } else if (strategyType === 'number') {
       registeredStrategies.push(new strategies.ByLength(strategy, callback, args, spreads));
+    } else {
+      throw new Error('unrecognized strategy type');
     }
 
     return { when: self.when, done: self.done };

--- a/lib/strategies.js
+++ b/lib/strategies.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function spread(currentArgs, spreads) {
   var newArgs, shouldSpread, argToSpread, isArray;
 
@@ -21,25 +23,41 @@ function spread(currentArgs, spreads) {
   return newArgs;
 };
 
-exports.ByLength = function (length, callback, target, spreads) {
-  var self = {}
-    , args = spread(Array.prototype.slice.apply(target.arguments), spreads || []);
+// returns an execution function given a callback and arguments
+function executor(callback, args) {
+  return function execute(context, fn) {
+    // if the context is explicitly defined, we use it.
+    // if we are NOT in strict mode, we can expect fn to actually be
+    // a function, so we'll use that instead.
+    var ctx = null;
+    if (context) {
+      ctx = context;
+    }
+    else if (typeof(fn) === 'function') {
+      ctx = fn;
+    }
+    return callback.apply(ctx, args);
+  };
+}
+
+exports.ByLength = function (length, callback, args, spreads) {
+  var self = {};
+
+  args = spread(args, spreads || []);
 
   self.isMatch = function () {
     return length == args.length;
   }
 
-  self.execute = function (context, spreads) {
-
-    return callback.apply((context || target), args);
-  }
+  self.execute = executor(callback, args);
 
   return self;
 };
 
-exports.ByType = function (types, callback, target, spreads) {
-  var self = {}
-    , args = spread(Array.prototype.slice.apply(target.arguments), spreads || []);
+exports.ByType = function (types, callback, args, spreads) {
+  var self = {};
+
+  args = spread(args, spreads || []);
 
   types = [].concat(types);
 
@@ -61,13 +79,11 @@ exports.ByType = function (types, callback, target, spreads) {
 
   self.isMatch = function () {
     for (var i in types) {
-      isMatch = matchesObject(types[i], args[i])
+      if (!(matchesObject(types[i], args[i])
           || matchesString(types[i], args[i])
           || matchesNumber(types[i], args[i])
           || matchesBoolean(types[i], args[i])
-          || args[i] instanceof types[i];
-
-      if (!isMatch)  {
+          || args[i] instanceof types[i])) {
         return false;
       }
     }
@@ -75,9 +91,7 @@ exports.ByType = function (types, callback, target, spreads) {
     return true;
   }
 
-  self.execute = function (context) {
-    return callback.apply((context || target), args);
-  }
+  self.execute = executor(callback, args);
 
   return self;
 };

--- a/lib/strategies.js
+++ b/lib/strategies.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var type = require('type-of');
+
 function spread(currentArgs, spreads) {
   var newArgs, shouldSpread, argToSpread, isArray;
 
@@ -33,7 +35,7 @@ function executor(callback, args) {
     if (context) {
       ctx = context;
     }
-    else if (typeof(fn) === 'function') {
+    else if (type(fn) === 'function') {
       ctx = fn;
     }
     return callback.apply(ctx, args);
@@ -61,29 +63,20 @@ exports.ByType = function (types, callback, args, spreads) {
 
   types = [].concat(types);
 
-  function matchesNumber(type, instance) {
-    return type.name === 'Number' && !isNaN(parseFloat(instance)) && isFinite(instance);
-  }
-
-  function matchesObject(type, instance) {
-    return type.name === 'Object' && instance != null && typeof instance === 'object';
-  }
-
-  function matchesString(type, instance) {
-    return type.name === 'String' && typeof instance === 'string';
-  }
-
-  function matchesBoolean(type, instance) {
-    return type.name === 'Boolean' && typeof instance === 'boolean';
+  // for built-ins, type() will always return the same string
+  // property "name" does, but lowercase.
+  function match(t, instance) {
+    return t !== null && t.name && t.name.toLowerCase() === type(instance);
   }
 
   self.isMatch = function () {
+    var a, t;
     for (var i in types) {
-      if (!(matchesObject(types[i], args[i])
-          || matchesString(types[i], args[i])
-          || matchesNumber(types[i], args[i])
-          || matchesBoolean(types[i], args[i])
-          || args[i] instanceof types[i])) {
+      t = types[i];
+      a = args[i]
+      if (!(match(t, a)
+        || (a === null && t === null)
+        || (type(a) === 'object' && a instanceof t))) {
         return false;
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argumenter",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "abstraction for function arguments",
   "main": "index.js",
   "scripts": {
@@ -13,12 +13,13 @@
     "url": "https://github.com/Trecenti/argumenter"
   },
   "devDependencies": {
-    "mocha": "~1.15.1",
-    "chai": "~1.8.1",
-    "sinon-chai": "~2.4.0",
-    "sinon": "~1.7.3"
+    "mocha": "^1.20.0",
+    "sinon-chai": "^2.5.0"
   },
   "engines": {
     "node": ">=0.10.12"
+  },
+  "dependencies": {
+    "is-arguments": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "node": ">=0.10.12"
   },
   "dependencies": {
-    "is-arguments": "^1.0.0"
+    "type-of": "^2.0.1"
   }
 }

--- a/tests/api-strict.js
+++ b/tests/api-strict.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var argumenter = require('../index');
+
+describe('strict mode: the argumenter api', function () {
+  describe('strict mode: when chained', function () {
+    it('does not throw', function () {
+      function fn() {
+        return argumenter(arguments)
+          .when(1, function(one) { return one; })
+          .when(0, function() { return 'no-arguments'; })
+          .done();
+      };
+
+      expect(fn).to.not.throw();
+    });
+
+    it('does not throws (if no strategy is defined)', function () {
+      function fn() {
+        return argumenter(arguments).done();
+      };
+
+      expect(fn).to.not.throw();
+    });
+
+    it('throws (when done is called in a wrong order)', function () {
+      function fn() {
+        return argumenter(arguments)
+          .when(1, function(one) { return one; })
+          .done()
+          .when(0, function() { return 'no-arguments'; });
+      };
+
+      expect(fn).to.throw();
+    });
+
+    it('throws (when spread called in a wrong order)', function () {
+      function fn() {
+        return argumenter(arguments)
+          .when(1, function(one) { return one; })
+          .spread(0)
+          .when(0, function() { return 'no-arguments'; });
+      };
+
+      expect(fn).to.throw();
+    });
+  });
+
+  it('can be called detached', function () {
+    function fn() {
+      var handler = argumenter(arguments);
+
+      handler.when(1, function(one) { return one; });
+      handler.spread(0);
+      handler.when(0, function() { return 'no-arguments'; });
+
+      return handler.done();
+    };
+
+    expect(fn).to.not.throw();
+  });
+
+  it('cannot accept a function', function () {
+    function fn() {
+      argumenter(fn);
+    }
+    expect(fn).to.throw();
+  });
+  
+  it('can accept named parameters', function () {
+    function fn(foo, bar) {
+      return argumenter(foo, bar)
+        .when([Number, Number], function (num1, num2) {
+          return num1 + num2;
+        })
+        .done();
+    }
+
+    expect(fn(2, 2)).to.equal(4);
+  })
+});

--- a/tests/by-length-strict.js
+++ b/tests/by-length-strict.js
@@ -1,0 +1,129 @@
+'use strict';
+
+var argumenter = require('../index');
+
+describe('strict mode: using argumenter by length', function () {
+  describe('strict mode: on a single argument functions', function () {
+    var fn;
+
+    describe('strict mode: with a single strategy', function () {
+      beforeEach(function () {
+        fn = function () {
+          return argumenter(arguments).when(1, function (first) { return first + '-argument'; }).done();
+        }
+      });
+
+      it('executes the strategy (when the number of arguments matches)', function () {
+        expect(fn('test')).to.equal('test-argument');
+      });
+
+      it('does not execute the strategy (when the number of arguments don\'t match)', function () {
+        expect(fn()).to.equal(undefined);
+      });
+    });
+
+    describe('strict mode: with multiple strategies', function () {
+      beforeEach(function () {
+        fn = function () {
+          return argumenter(arguments)
+                  .when(1, function (first) { return first + '-argument'; })
+                  .when(0, function () { return 'no-arguments'; })
+                  .done();
+        }
+      });
+
+      it('executes the strategy (for length == 1)', function () {
+        expect(fn('test')).to.equal('test-argument');
+      });
+
+      it('executes the strategy (for length == 0)', function () {
+        expect(fn()).to.equal('no-arguments');
+      });
+
+      it('does not execute the strategy (when the number of arguments don\'t match)', function () {
+        expect(fn('a', 'b')).to.equal(undefined);
+      });
+    });
+  });
+
+  describe('strict mode: on a multiple arguments functions', function () {
+    var fn;
+
+    describe('strict mode: with a single strategy', function () {
+      beforeEach(function () {
+        fn = function () {
+          return argumenter(arguments).when(2, function (first, second) {
+            return {
+              first: first + '-argument',
+              second: second + '-argument'
+            };
+          }).done();
+        }
+      });
+
+      it('executes the strategy (when the number of arguments matches)', function () {
+        expect(fn('first', 'second')).to.deep.equal(
+          { first: 'first-argument', second: 'second-argument' }
+        );
+      });
+
+      describe('strict mode: when the number of arguments do not match', function () {
+        it('does not execute the strategy (when one of the arguments is passed)', function () {
+          expect(fn('first')).to.equal(undefined);
+        });
+
+        it('does not execute the strategy (when no argument is passed)', function () {
+          expect(fn()).to.equal(undefined);
+        });
+      });
+    });
+
+    describe('strict mode: with multiple strategies', function () {
+      beforeEach(function () {
+        fn = function () {
+          var result;
+
+          function noArguments() {
+            return  'no-arguments';
+          }
+
+          function oneArgument(first) {
+            return  first + '-argument';
+          }
+
+          function twoArguments(first, second) {
+            return {
+              first: first + '-argument',
+              second: second + '-argument'
+            };
+          }
+
+          result = argumenter(arguments)
+                    .when(0, noArguments)
+                    .when(1, oneArgument)
+                    .when(2, twoArguments).done();
+
+          return result;
+        }
+      });
+
+      it('executes the strategy (when length == 2)', function () {
+        expect(fn('first', 'second')).to.deep.equal(
+          { first: 'first-argument', second: 'second-argument' }
+        );
+      });
+
+      it('executes the strategy (when length == 1)', function () {
+        expect(fn('first')).to.equal('first-argument');
+      });
+
+      it('executes the strategy (when no argument is passed)', function () {
+        expect(fn()).to.equal('no-arguments');
+      });
+
+      it('does not execute the strategy (when the number of arguments do not match)', function () {
+        expect(fn('first', 'second', 'third')).to.equal(undefined);
+      });
+    });
+  });
+});

--- a/tests/by-type-strict.js
+++ b/tests/by-type-strict.js
@@ -1,0 +1,150 @@
+'use strict';
+
+var argumenter = require('../index')
+  , sinon = require('sinon');
+
+describe('strict mode: using argumenter by type', function () {
+  describe('strict mode: on a single argument functions', function () {
+    var fn;
+
+    describe('strict mode: with a single strategy', function () {
+      beforeEach(function () {
+        fn = function () {
+          return argumenter(arguments).when(Function, function (firstFn) { return firstFn('my-fn-call'); }).done();
+        }
+      });
+
+      it('executes the strategy (when the argument is a function)', function () {
+        var fnArg = sinon.spy();
+
+        fn(fnArg);
+
+        expect(fnArg).to.have.been.calledWith('my-fn-call');
+      });
+
+      it('does not execute the strategy (when the argument is not a function)', function () {
+        expect(fn(1)).to.equal(undefined);
+      });
+    });
+
+
+    describe('strict mode: with multiple strategies', function () {
+      beforeEach(function () {
+        fn = function () {
+          return argumenter(arguments)
+                  .when(Function, function (firstFn) { return firstFn('my-fn-call'); })
+                  .when(Array, function (array) { return array.concat(1); })
+                  .when(Number, function (number) { return number + 1; })
+                  .when(Object, function (obj) { obj.id = 'id'; return obj; })
+                  .when(String, function (string) { return string.replace(/\s/g, '-'); })
+                  .when(Boolean, function (bool) { return !bool; })
+                  .when(0, function () { return 'no-arguments'; })
+                  .done();
+        }
+      });
+
+      it('executes the strategy (for function)', function () {
+        var fnArg = sinon.spy();
+
+        fn(fnArg);
+
+        expect(fnArg).to.have.been.calledWith('my-fn-call');
+      });
+
+      it('executes the strategy (for array)', function () {
+        expect(fn([])).to.eql([1]);
+      });
+
+      it('executes the strategy (for number)', function () {
+        expect(fn(1)).to.equal(2);
+      });
+
+      it('executes the strategy (for object)', function () {
+        expect(fn({})).to.deep.equal({ id: 'id' });
+      });
+
+      it('executes the strategy (for string)', function () {
+        expect(fn('my string')).to.equal('my-string');
+      });
+
+      it('executes the strategy (for boolean)', function () {
+        expect(fn(true)).to.equal(false);
+      });
+
+      it('executes the strategy (for length == 0)', function () {
+        expect(fn()).to.equal('no-arguments');
+      });
+
+      it('does not execute the strategy (when the arguments do not match any strategy)', function () {
+        expect(fn(null, 'b')).to.equal(undefined);
+      });
+    });
+  });
+
+  describe('strict mode: on a multiple arguments functions', function () {
+    var fn;
+
+    describe('strict mode: with a single strategy', function () {
+      beforeEach(function () {
+        fn = function () {
+          return argumenter(arguments)
+            .when([Function, Number], function (func, number) {
+              func('my-fn-call');
+              return number + 1;
+            }).done();
+        }
+      });
+
+      it('executes the strategy (when the arguments match)', function () {
+        var fnArg, result;
+        fnArg = sinon.spy();
+
+        result = fn(fnArg, 1);
+
+        expect(result).to.equal(2);
+        expect(fnArg).to.have.been.calledWith('my-fn-call');
+      });
+
+      it('does not execute the strategy (when the argument do not match)', function () {
+        expect(fn(1, function () {})).to.equal(undefined);
+      });
+    });
+
+    describe('strict mode: with multiple strategies', function () {
+      beforeEach(function () {
+        fn = function () {
+          return argumenter(arguments)
+            .when([Function, Number], function (func, number) {
+              func('my-fn-call');
+              return number + 1;
+            })
+            .when(Boolean, function (bool) { return !bool; })
+            .when(0, function () { return 'no-arguments'; })
+            .done();
+        }
+      });
+
+      it('executes the strategy (when the arguments match [Function, Number])', function () {
+        var fnArg, result;
+        fnArg = sinon.spy();
+
+        result = fn(fnArg, 1);
+
+        expect(result).to.equal(2);
+        expect(fnArg).to.have.been.calledWith('my-fn-call');
+      });
+
+      it('executes the strategy (when the arguments match Boolean)', function () {
+        expect(fn(true)).to.equal(false);
+      });
+
+      it('executes the strategy (when the arguments match Boolean)', function () {
+        expect(fn()).to.equal('no-arguments');
+      });
+
+      it('does not execute the strategy (when the arguments do not match any strategy)', function () {
+        expect(fn(null, 'b')).to.equal(undefined);
+      });
+    });
+  });
+});

--- a/tests/by-type-strict.js
+++ b/tests/by-type-strict.js
@@ -27,17 +27,33 @@ describe('strict mode: using argumenter by type', function () {
       });
     });
 
+    describe('strict mode: invalid strategy', function () {
+      it('should fail if given an invalid strategy', function () {
+        expect(function () {
+          argumenter(arguments)
+            .when('invalid', function () {
+            })
+        }).to.throw();
+      });
+    });
 
     describe('strict mode: with multiple strategies', function () {
+
+      var Foo;
+
       beforeEach(function () {
+        Foo = function () {
+        };
         fn = function () {
           return argumenter(arguments)
                   .when(Function, function (firstFn) { return firstFn('my-fn-call'); })
-                  .when(Array, function (array) { return array.concat(1); })
                   .when(Number, function (number) { return number + 1; })
+                  .when(Foo, function(foo) { return 'bar'; })
                   .when(Object, function (obj) { obj.id = 'id'; return obj; })
+                  .when(Array, function (array) { return array.concat(1); })
                   .when(String, function (string) { return string.replace(/\s/g, '-'); })
                   .when(Boolean, function (bool) { return !bool; })
+                  .when(null, function() { return 'null'; })
                   .when(0, function () { return 'no-arguments'; })
                   .done();
         }
@@ -75,8 +91,16 @@ describe('strict mode: using argumenter by type', function () {
         expect(fn()).to.equal('no-arguments');
       });
 
+      it('executes the stategy for null', function () {
+        expect(fn(null)).to.equal('null');
+      })
+
       it('does not execute the strategy (when the arguments do not match any strategy)', function () {
-        expect(fn(null, 'b')).to.equal(undefined);
+        expect(fn(undefined, 'b')).to.equal(undefined);
+      });
+
+      it('executed strategy for custom type', function () {
+        expect(fn(new Foo())).to.equal('bar');
       });
     });
   });

--- a/tests/context-strict.js
+++ b/tests/context-strict.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var argumenter = require('../index');
+
+describe('strict mode: context binding', function () {
+  var context;
+
+  it('uses context if passed to done', function () {
+    context = new (function () {
+      this.fn = function () {
+        return argumenter(arguments)
+                  .when(Number, function () { return this; })
+                  .when(2, function () { return this; })
+                  .done(this);
+      }
+    })();
+
+    expect(context.fn(1)).to.equal(context);
+    expect(context.fn(1, 2)).to.equal(context);
+  });
+
+  // this is an expected failure.
+  it('uses null as context if none passed to done', function () {
+    context = new (function () {
+      this.fn = function () {
+        return argumenter(arguments)
+                  .when(Number, function () { return this; })
+                  .when(2, function () { return this; })
+                  .done();
+      }
+    })();
+
+    expect(context.fn(1)).to.be.null;
+    expect(context.fn(1, 2)).to.be.null;
+  });
+});

--- a/tests/spreader-strict.js
+++ b/tests/spreader-strict.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var argumenter = require('../index');
+
+describe('strict mode: spreader', function () {
+  it('spread array argument on a give index', function () {
+    function fn() {
+      var handler = argumenter(arguments);
+
+      handler.spread(0).spread(2)
+        .when([String, Object, Number, Array], function (string, obj, n, array) {
+          return {
+            string: string,
+            obj: obj,
+            number: n,
+            array: array
+          };
+        });
+
+      return handler.done();
+    };
+
+    expect(
+      fn(['test', { a: 1 }], 1, [[3,4]])
+    ).to.deep.equal({
+      string: 'test',
+      obj: { a: 1 },
+      number: 1,
+      array: [3, 4]
+    });
+  });
+
+  it('does not throw if arg to spread is not an array', function () {
+    function fn() {
+      var handler = argumenter(arguments);
+
+      handler.spread(0).spread(1).spread(2);
+
+      handler
+        .when([String, Object, Number, Array], function (string, obj, n, array) {
+          return {
+            string: string,
+            obj: obj,
+            number: n,
+            array: array
+          };
+        });
+
+      return handler.done();
+    };
+
+    expect(fn(['test', { a: 1 }], 1, [[3,4]])).to.deep.equal({
+      string: 'test',
+      obj: { a: 1 },
+      number: 1,
+      array: [3, 4]
+    });
+  });
+});


### PR DESCRIPTION
Currently, `argumenter()` does not work in strict mode, because of the use of `Function.arguments`, which will throw an exception.
- `argumenter()` now works in strict mode.
- in strict mode, you must pass arguments to `argumenter()` instead of the function itself.
- this _is_ backwards compatible, and you can still pass a function to argumenter() if working in non-strict mode.
- caveat: in strict mode, not passing a context to `done()` will _not_ execute the callback in the context of the function itself.  this is impossible, since we cannot pass the function to `argumenter()` and thus have no reference to it.  if you want the function to be the context, then pass it to `done()`.  this was undocumented and seems like kind of an edge case, so I think it's probably OK.
- did a little bit of cleanup
- duplicated the tests to all run in strict mode and again in non-strict mode.  there's probably a better way to do this, but I didn't have anything off the top of my head.

**UPDATE**
- eschewing package `is-arguments` in favor of the more flexible `type-of`, which will help the type checking.
- added support for `null` strategy.
- reduced lines of code in matching logic
- updated tests to show that `Array` and `null` strategies work; did not modify the non-strict tests
- added a test to assert that pseudoclasses work as strategies
- throws if you pass something weird as a strategy; added test. (if you start using strings as strategies, you've basically made a really complicated switch statement)

great module.  exactly what I was looking for.
